### PR TITLE
Add footer text, slide numbers, and auto-fit features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ This plugin allows you to customize the Slides [Obsidian](https://obsidian.md) c
 - **Left-Align Lists**: Enable left-aligned bulleted and numbered lists in presentation mode for a cleaner, more readable layout, with a 1em left margin for proper spacing.
 - **Immediate Keyboard Input**: Automatically switches to reading mode when entering Slides mode so spacebar and arrows work without having to click your presentation, and restores your previous mode (e.g., edit or source) when exiting.
 - **Custom Font Support**: Use the text font settings specified in your Obsidian settings.
+- **Footer Text**: Display configurable text at the bottom of every slide except the title slide. Set via "Footer text" in settings; leave empty to disable. Uses plain text (no HTML) and adapts color automatically for dark themes.
+- **Slide Numbers**: Show a slide number on each slide, excluding the title slide. Numbers start at 1 for the second slide. Position is configurable: bottom-left (default) or bottom-right. The position dropdown only appears when slide numbers are enabled.
+- **Auto-Fit Slides**: Automatically shrinks overflowing slide content to fit the viewport using CSS zoom, preserving layout and backgrounds. Enabled by default; can be toggled off in settings.
 - **Mobile Support**: Works on iPad and other mobile devices with sensible touch-friendly defaults (navigation arrows shown by default on mobile).
 
 ## Installation
@@ -35,7 +38,7 @@ This plugin allows you to customize the Slides [Obsidian](https://obsidian.md) c
 ## Usage
 
 1. **Enable the Plugin**: Activate it in the Community Plugins settings.
-2. **Configure Settings**: Use the settings tab to toggle navigation arrow visibility, set the progress bar height, choose transition effects, and enable left-aligned lists.
+2. **Configure Settings**: Use the settings tab to toggle navigation arrow visibility, set the progress bar height, choose transition effects, enable left-aligned lists, set footer text, enable slide numbers, and configure auto-fit behavior.
 3. **Start a Presentation**: Open a note with Slides-compatible Markdown (e.g., using `---` for slides) and use the "Slides: Start Presentation" command from the Command Palette.
 4. **Using Keys for Navigation**: You can use the spacebar and arrow keys to go between slides as normal and the ESC key will exit your presentation.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ export default class CustomSlidesPlugin extends Plugin {
   private modeObserver!: ModeObserver;
   private slideManipulator!: SlideManipulator;
   private footerEl: HTMLElement | null = null;
+  private slideNumberEl: HTMLElement | null = null;
   private _footerVisibilityHandler: (() => void) | null = null;
   private _slideNumberHandler: (() => void) | null = null;
 
@@ -40,7 +41,7 @@ export default class CustomSlidesPlugin extends Plugin {
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
     this.applyDynamicStyles(); // Reapply dynamic styles after saving
-    this.updateSlideNumbers();
+    this.createSlideNumber();
   }
 
   private applyDynamicStyles(): void {
@@ -147,26 +148,57 @@ export default class CustomSlidesPlugin extends Plugin {
     }
   }
 
-  private updateSlideNumbers(): void {
-    // Always clear existing numbers first (idempotent)
-    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
-
+  private createSlideNumber(): void {
+    this.destroySlideNumber();
     if (!this.settings.showSlideNumbers) return;
 
     const reveal = document.querySelector(".reveal");
     if (!reveal) return;
 
-    // Use leaf slides so vertical stacks get distinct numbers per child slide
-    const leafSlides = Array.from(reveal.querySelectorAll(".slides section")).filter(s => s.querySelectorAll("section").length === 0);
+    const numEl = document.createElement("div");
+    numEl.className = "custom-slide-number";
+    numEl.classList.add(`slide-number-${this.settings.slideNumberPosition}`);
+    reveal.appendChild(numEl);
+    this.slideNumberEl = numEl;
 
-    leafSlides.forEach((section, index) => {
-      if (index === 0) return; // Skip title slide
-      const numEl = document.createElement("div");
-      numEl.className = "custom-slide-number";
-      numEl.classList.add(`slide-number-${this.settings.slideNumberPosition}`);
-      numEl.textContent = String(index);
-      section.appendChild(numEl);
-    });
+    this._slideNumberHandler = () => this.updateSlideNumberVisibility();
+    reveal.addEventListener("slidechanged", this._slideNumberHandler);
+    reveal.addEventListener("ready", this._slideNumberHandler);
+    this.updateSlideNumberVisibility();
+  }
+
+  private updateSlideNumberVisibility(): void {
+    if (!this.slideNumberEl) return;
+    const slidesContainer = document.querySelector(".reveal .slides");
+    if (!slidesContainer) return;
+
+    const leafSlides = Array.from(slidesContainer.querySelectorAll("section")).filter(s => s.querySelectorAll("section").length === 0);
+    const currentSlide = leafSlides.find(s => s.classList.contains("present"));
+
+    if (!currentSlide || currentSlide === leafSlides[0]) {
+      this.slideNumberEl.style.display = "none";
+    } else {
+      const index = leafSlides.indexOf(currentSlide);
+      this.slideNumberEl.style.display = "";
+      this.slideNumberEl.textContent = String(index);
+    }
+  }
+
+  private destroySlideNumber(): void {
+    if (this.slideNumberEl) {
+      this.slideNumberEl.remove();
+      this.slideNumberEl = null;
+    }
+    if (this._slideNumberHandler) {
+      const reveal = document.querySelector(".reveal");
+      if (reveal) {
+        reveal.removeEventListener("slidechanged", this._slideNumberHandler);
+        reveal.removeEventListener("ready", this._slideNumberHandler);
+      }
+      this._slideNumberHandler = null;
+    }
+    // Cleanup any lingering ones from previous methods
+    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
   }
 
   private setupModeObserver(): void {
@@ -184,24 +216,14 @@ export default class CustomSlidesPlugin extends Plugin {
       window.addEventListener("keydown", this.handleWASD, true);
     }
     this.createFooter();
-    this.updateSlideNumbers();
-    const reveal = document.querySelector(".reveal");
-    if (reveal) {
-      this._slideNumberHandler = () => this.updateSlideNumbers();
-      reveal.addEventListener("slidechanged", this._slideNumberHandler);
-    }
+    this.createSlideNumber();
   }
 
   public onExitSlidesMode(): void {
     this.slideManipulator.destroy();
     window.removeEventListener("keydown", this.handleWASD, true);
     this.destroyFooter();
-    const reveal = document.querySelector(".reveal");
-    if (reveal && this._slideNumberHandler) {
-      reveal.removeEventListener("slidechanged", this._slideNumberHandler);
-    }
-    this._slideNumberHandler = null;
-    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
+    this.destroySlideNumber();
   }
 
   private handleWASD = (e: KeyboardEvent): void => {
@@ -253,13 +275,8 @@ export default class CustomSlidesPlugin extends Plugin {
   };
 
   onunload(): void {
-    const reveal = document.querySelector(".reveal");
-    if (reveal && this._slideNumberHandler) {
-      reveal.removeEventListener("slidechanged", this._slideNumberHandler);
-      this._slideNumberHandler = null;
-    }
+    this.destroySlideNumber();
     this.destroyFooter();
-    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
     const body = document.body;
 
     // Remove all modifier classes

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,9 @@ export default class CustomSlidesPlugin extends Plugin {
   settings!: CustomSlidesSettings;
   private modeObserver!: ModeObserver;
   private slideManipulator!: SlideManipulator;
+  private footerEl: HTMLElement | null = null;
+  private _footerVisibilityHandler: (() => void) | null = null;
+  private _slideNumberHandler: (() => void) | null = null;
 
   async onload(): Promise<void> {
     try {
@@ -37,6 +40,7 @@ export default class CustomSlidesPlugin extends Plugin {
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
     this.applyDynamicStyles(); // Reapply dynamic styles after saving
+    this.updateSlideNumbers();
   }
 
   private applyDynamicStyles(): void {
@@ -97,6 +101,70 @@ export default class CustomSlidesPlugin extends Plugin {
     }
   }
 
+  private createFooter(): void {
+    if (!this.settings.footerText.trim()) {
+      this.footerEl = null;
+      return;
+    }
+    const reveal = document.querySelector(".reveal");
+    if (!reveal) return;
+
+    const footer = document.createElement("div");
+    footer.className = "custom-slides-footer";
+    footer.textContent = this.settings.footerText;
+    reveal.appendChild(footer);
+    this.footerEl = footer;
+
+    this._footerVisibilityHandler = () => this.updateFooterVisibility();
+    reveal.addEventListener("slidechanged", this._footerVisibilityHandler);
+    reveal.addEventListener("ready", this._footerVisibilityHandler);
+    this.updateFooterVisibility();
+  }
+
+  private updateFooterVisibility(): void {
+    if (!this.footerEl) return;
+    const slidesContainer = document.querySelector(".reveal .slides");
+    if (!slidesContainer) return;
+    const currentSection = slidesContainer.querySelector(":scope > section.present");
+    const firstSection = slidesContainer.querySelector(":scope > section:first-child");
+    this.footerEl.style.display = (currentSection === firstSection) ? "none" : "";
+  }
+
+  private destroyFooter(): void {
+    if (this.footerEl) {
+      this.footerEl.remove();
+      this.footerEl = null;
+    }
+    if (this._footerVisibilityHandler) {
+      const reveal = document.querySelector(".reveal");
+      if (reveal) {
+        reveal.removeEventListener("slidechanged", this._footerVisibilityHandler);
+        reveal.removeEventListener("ready", this._footerVisibilityHandler);
+      }
+      this._footerVisibilityHandler = null;
+    }
+  }
+
+  private updateSlideNumbers(): void {
+    // Always clear existing numbers first (idempotent)
+    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
+
+    if (!this.settings.showSlideNumbers) return;
+
+    const reveal = document.querySelector(".reveal");
+    if (!reveal) return;
+
+    const sections = reveal.querySelectorAll(".slides > section");
+    sections.forEach((section, index) => {
+      if (index === 0) return; // Skip title slide
+      const numEl = document.createElement("div");
+      numEl.className = "custom-slide-number";
+      numEl.classList.add(`slide-number-${this.settings.slideNumberPosition}`);
+      numEl.textContent = String(index);
+      section.appendChild(numEl);
+    });
+  }
+
   private setupModeObserver(): void {
     this.modeObserver = new ModeObserver(this);
     this.modeObserver.setup();
@@ -111,11 +179,25 @@ export default class CustomSlidesPlugin extends Plugin {
     if (this.settings.enableWASD) {
       window.addEventListener("keydown", this.handleWASD, true);
     }
+    this.createFooter();
+    this.updateSlideNumbers();
+    const reveal = document.querySelector(".reveal");
+    if (reveal) {
+      this._slideNumberHandler = () => this.updateSlideNumbers();
+      reveal.addEventListener("slidechanged", this._slideNumberHandler);
+    }
   }
 
   public onExitSlidesMode(): void {
     this.slideManipulator.destroy();
     window.removeEventListener("keydown", this.handleWASD, true);
+    this.destroyFooter();
+    const reveal = document.querySelector(".reveal");
+    if (reveal && this._slideNumberHandler) {
+      reveal.removeEventListener("slidechanged", this._slideNumberHandler);
+    }
+    this._slideNumberHandler = null;
+    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
   }
 
   private handleWASD = (e: KeyboardEvent): void => {
@@ -167,6 +249,8 @@ export default class CustomSlidesPlugin extends Plugin {
   };
 
   onunload(): void {
+    this.destroyFooter();
+    document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
     const body = document.body;
 
     // Remove all modifier classes

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,9 +125,11 @@ export default class CustomSlidesPlugin extends Plugin {
     if (!this.footerEl) return;
     const slidesContainer = document.querySelector(".reveal .slides");
     if (!slidesContainer) return;
-    const currentSection = slidesContainer.querySelector(":scope > section.present");
-    const firstSection = slidesContainer.querySelector(":scope > section:first-child");
-    this.footerEl.style.display = (currentSection === firstSection) ? "none" : "";
+
+    // Use leaf slides to correctly handle vertical stacks
+    const leafSlides = Array.from(slidesContainer.querySelectorAll("section")).filter(s => s.querySelectorAll("section").length === 0);
+    const currentSlide = leafSlides.find(s => s.classList.contains("present"));
+    this.footerEl.style.display = (currentSlide === leafSlides[0]) ? "none" : "";
   }
 
   private destroyFooter(): void {
@@ -154,8 +156,10 @@ export default class CustomSlidesPlugin extends Plugin {
     const reveal = document.querySelector(".reveal");
     if (!reveal) return;
 
-    const sections = reveal.querySelectorAll(".slides > section");
-    sections.forEach((section, index) => {
+    // Use leaf slides so vertical stacks get distinct numbers per child slide
+    const leafSlides = Array.from(reveal.querySelectorAll(".slides section")).filter(s => s.querySelectorAll("section").length === 0);
+
+    leafSlides.forEach((section, index) => {
       if (index === 0) return; // Skip title slide
       const numEl = document.createElement("div");
       numEl.className = "custom-slide-number";
@@ -249,6 +253,11 @@ export default class CustomSlidesPlugin extends Plugin {
   };
 
   onunload(): void {
+    const reveal = document.querySelector(".reveal");
+    if (reveal && this._slideNumberHandler) {
+      reveal.removeEventListener("slidechanged", this._slideNumberHandler);
+      this._slideNumberHandler = null;
+    }
     this.destroyFooter();
     document.querySelectorAll(".custom-slide-number").forEach(el => el.remove());
     const body = document.body;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { Platform } from "obsidian";
 
 export type TransitionType = "none" | "fade" | "slide-horizontal" | "slide-vertical";
+export type SlideNumberPosition = "bottom-left" | "bottom-right";
 
 export interface CustomSlidesSettings {
   theme: string;
@@ -16,6 +17,10 @@ export interface CustomSlidesSettings {
   enableZoom: boolean;
   enableWASD: boolean;
   transition: TransitionType;
+  footerText: string;
+  showSlideNumbers: boolean;
+  slideNumberPosition: SlideNumberPosition;
+  enableAutoFit: boolean;
 }
 
 export const DEFAULT_SETTINGS: CustomSlidesSettings = {
@@ -32,6 +37,10 @@ export const DEFAULT_SETTINGS: CustomSlidesSettings = {
   enableZoom: true,
   enableWASD: false,
   transition: "slide-horizontal",
+  footerText: "",
+  showSlideNumbers: false,
+  slideNumberPosition: "bottom-left",
+  enableAutoFit: true,
 };
 
 /**

--- a/src/ui/settings-tab.ts
+++ b/src/ui/settings-tab.ts
@@ -1,7 +1,7 @@
 import { App, PluginSettingTab , SettingGroup} from "obsidian";
 import CustomSlidesPlugin from "../main";
 
-import { TransitionType } from "../settings";
+import { SlideNumberPosition, TransitionType } from "../settings";
 
 export class CustomSlidesSettingTab extends PluginSettingTab {
   plugin: CustomSlidesPlugin;
@@ -197,6 +197,62 @@ export class CustomSlidesSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.enableZoom)
           .onChange(async (value: any) => {
             this.plugin.settings.enableZoom = value;
+            await this.plugin.saveSettings();
+          }));
+    });
+
+    generalGroup.addSetting((setting: any) => {
+      setting
+        .setName("Footer text")
+        .setDesc("Text displayed at the bottom of every slide except the title slide. Leave empty for no footer.")
+        .addText((text: any) => text
+          .setPlaceholder("e.g. Confidential")
+          .setValue(this.plugin.settings.footerText)
+          .onChange(async (value: any) => {
+            this.plugin.settings.footerText = value;
+            await this.plugin.saveSettings();
+          }));
+    });
+
+    generalGroup.addSetting((setting: any) => {
+      setting
+        .setName("Show slide numbers")
+        .setDesc("Display a slide number on each slide, excluding the title slide.")
+        .addToggle((toggle: any) => toggle
+          .setValue(this.plugin.settings.showSlideNumbers)
+          .onChange(async (value: any) => {
+            this.plugin.settings.showSlideNumbers = value;
+            await this.plugin.saveSettings();
+            this.display();
+          }));
+    });
+
+    if (this.plugin.settings.showSlideNumbers) {
+      generalGroup.addSetting((setting: any) => {
+        setting
+          .setName("Slide number position")
+          .setDesc("Choose where the slide number appears.")
+          .addDropdown((dropdown: any) => dropdown
+            .addOptions({
+              "bottom-left": "Bottom left",
+              "bottom-right": "Bottom right"
+            })
+            .setValue(this.plugin.settings.slideNumberPosition)
+            .onChange(async (value: any) => {
+              this.plugin.settings.slideNumberPosition = value as SlideNumberPosition;
+              await this.plugin.saveSettings();
+            }));
+      });
+    }
+
+    generalGroup.addSetting((setting: any) => {
+      setting
+        .setName("Auto-fit slides")
+        .setDesc("Automatically shrink overflowing slide content to fit the viewport.")
+        .addToggle((toggle: any) => toggle
+          .setValue(this.plugin.settings.enableAutoFit)
+          .onChange(async (value: any) => {
+            this.plugin.settings.enableAutoFit = value;
             await this.plugin.saveSettings();
           }));
     });

--- a/src/utils/slide-manipulator.ts
+++ b/src/utils/slide-manipulator.ts
@@ -71,9 +71,12 @@ export class SlideManipulator {
   private handleSlideChanged = (): void => {
     // 1. Reset the previous slide's transform so it doesn't stay messed up
     this.reset();
-    
+
     // 2. Refresh the pointer to the new current slide
     this.refreshSlidesElement();
+
+    // 3. Auto-fit overflowing content to the viewport
+    this.fitSlideToViewport();
   };
 
   destroy(): void {
@@ -209,7 +212,74 @@ export class SlideManipulator {
       (this.slidesElement.style as any).scale = "";
       // eslint-disable-next-line obsidianmd/no-static-styles-assignment
       this.slidesElement.style.transformOrigin = "";
+      // eslint-disable-next-line obsidianmd/no-static-styles-assignment
+      (this.slidesElement.style as any).zoom = "";
     }
     document.body.classList.remove("is-panning");
   };
+
+  /**
+   * Auto-fit the current slide to the viewport using CSS zoom.
+   *
+   * CSS sets min-height: 100% on sections so they fill the .slides container.
+   * If content exceeds the container height, the section grows beyond it.
+   * This function detects that overflow and applies CSS zoom to shrink the
+   * section back to fit. CSS zoom (unlike transform: scale) affects layout,
+   * so the slide background shrinks with the content.
+   *
+   * Called once on slide change — user can zoom/pan freely after.
+   */
+  private fitSlideToViewport(): void {
+    if (!this.plugin.settings.enableAutoFit) return;
+    if (!this.slidesElement) return;
+    const targetSlide = this.slidesElement;
+    // Double rAF ensures reveal.js layout is fully settled before measuring
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (this.slidesElement === targetSlide) {
+          this.applyAutoFitZoom();
+        }
+      });
+    });
+    // Re-measure after images finish loading (they may change scrollHeight)
+    const images = targetSlide.querySelectorAll("img");
+    images.forEach((img) => {
+      if (!img.complete) {
+        img.addEventListener("load", () => {
+          if (this.slidesElement === targetSlide) {
+            this.applyAutoFitZoom();
+          }
+        }, { once: true });
+      }
+    });
+  }
+
+  private applyAutoFitZoom(): void {
+    if (!this.slidesElement) return;
+    const section = this.slidesElement;
+    // Reset any previous zoom so we measure natural size
+    (section.style as any).zoom = "";
+    const slidesContainer = section.closest(".slides");
+    if (!slidesContainer) return;
+    const containerH = (slidesContainer as HTMLElement).clientHeight;
+    const naturalH = section.scrollHeight;
+    if (naturalH > containerH) {
+      const zoomFactor = containerH / naturalH;
+      // eslint-disable-next-line obsidianmd/no-static-styles-assignment
+      (section.style as any).zoom = `${zoomFactor}`;
+      // CSS zoom interacts non-linearly with reveal.js's transform: scale().
+      // A single screen-pixel correction only closes ~50% of the gap, so we
+      // square the correction factor to compensate in one pass.
+      requestAnimationFrame(() => {
+        if (!this.slidesElement || !slidesContainer) return;
+        const sectionRect = this.slidesElement.getBoundingClientRect();
+        const containerRect = (slidesContainer as HTMLElement).getBoundingClientRect();
+        if (sectionRect.height > containerRect.height + 1) {
+          const correction = containerRect.height / sectionRect.height;
+          const currentZoom = parseFloat((this.slidesElement.style as any).zoom) || 1;
+          (this.slidesElement.style as any).zoom = `${currentZoom * correction * correction}`;
+        }
+      });
+    }
+  }
 }

--- a/src/utils/slide-manipulator.ts
+++ b/src/utils/slide-manipulator.ts
@@ -4,11 +4,11 @@ export class SlideManipulator {
   private plugin: CustomSlidesPlugin;
   private revealContainer: HTMLElement | null = null;
   private slidesElement: HTMLElement | null = null;
-  
+
   private scale = 1;
   private translateX = 0;
   private translateY = 0;
-  
+
   private isPanning = false;
   private lastMouseX = 0;
   private lastMouseY = 0;
@@ -32,7 +32,7 @@ export class SlideManipulator {
 
     // Wheel event for zooming
     this.revealContainer.addEventListener("wheel", this.handleWheel, { passive: false });
-    
+
     // Mouse events for panning
     this.revealContainer.addEventListener("mousedown", this.handleMouseDown);
     this.revealContainer.addEventListener("contextmenu", this.handleContextMenu);
@@ -41,10 +41,10 @@ export class SlideManipulator {
 
     // Reset on slide change
     this.revealContainer.addEventListener("slidechanged", this.handleSlideChanged);
-    
+
     // Also handle 'ready' event when reveal.js has finished initializing
     this.revealContainer.addEventListener("ready", this.handleSlideChanged);
-    
+
     // Initial refresh in case it's already ready
     this.refreshSlidesElement();
   }
@@ -55,12 +55,12 @@ export class SlideManipulator {
     // Reveal.js might not have added .present immediately on the first slide
     // So we'll try to find the current indices and target the matching section
     this.slidesElement = this.revealContainer.querySelector(".slides > section.present") as HTMLElement;
-    
+
     // If not found, try the first section as a fallback for the very first launch
     if (!this.slidesElement) {
       this.slidesElement = this.revealContainer.querySelector(".slides > section") as HTMLElement;
     }
-    
+
     // Handle nested vertical slides
     const verticalSlide = this.slidesElement?.querySelector("section.present") as HTMLElement;
     if (verticalSlide) {
@@ -89,7 +89,7 @@ export class SlideManipulator {
     }
     window.removeEventListener("mousemove", this.handleMouseMove);
     window.removeEventListener("mouseup", this.handleMouseUp);
-    
+
     this.reset();
     this.revealContainer = null;
     this.slidesElement = null;
@@ -97,7 +97,7 @@ export class SlideManipulator {
 
   private handleContextMenu = (e: MouseEvent): void => {
     if (!this.plugin.settings.enablePan && !this.plugin.settings.enableZoom) return;
-    
+
     // Right click to reset
     e.preventDefault();
     this.reset();
@@ -115,9 +115,9 @@ export class SlideManipulator {
     if (newScale !== this.scale) {
       // Zoom to cursor logic:
       // We want to keep the point under the cursor fixed in viewport coordinates.
-      
+
       const rect = this.slidesElement.getBoundingClientRect();
-      
+
       // Calculate cursor position relative to the CENTER of the slides element
       // because CSS 'scale' and 'translate' independent properties use center origin by default.
       const centerX = rect.left + rect.width / 2;
@@ -136,7 +136,7 @@ export class SlideManipulator {
       // Update translation to keep the content position fixed
       this.translateX += contentX * (oldScale - newScale);
       this.translateY += contentY * (oldScale - newScale);
-      
+
       this.applyTransform();
     }
   };
@@ -149,7 +149,7 @@ export class SlideManipulator {
     this.lastMouseX = e.clientX;
     this.lastMouseY = e.clientY;
     document.body.classList.add("is-panning");
-    
+
     // Prevent default to avoid text selection or drag-and-drop ghost images
     e.preventDefault();
   };
@@ -182,7 +182,7 @@ export class SlideManipulator {
 
   private applyTransform(): void {
     if (!this.slidesElement) return;
-    
+
     // We must ensure the transform-origin is set to the center (0,0 of the coordinate space)
     // to make our translation and scaling math consistent.
     // Reveal.js slides usually have their origin in the center by default, 
@@ -212,8 +212,6 @@ export class SlideManipulator {
       (this.slidesElement.style as any).scale = "";
       // eslint-disable-next-line obsidianmd/no-static-styles-assignment
       this.slidesElement.style.transformOrigin = "";
-      // eslint-disable-next-line obsidianmd/no-static-styles-assignment
-      (this.slidesElement.style as any).zoom = "";
     }
     document.body.classList.remove("is-panning");
   };

--- a/styles.css
+++ b/styles.css
@@ -574,7 +574,7 @@ body.is-panning {
   color: rgba(150, 150, 150, 0.7);
   font-family: var(--slides-font-interface, var(--slides-font-text, inherit));
   pointer-events: none;
-  z-index: 10;
+  z-index: 30;
   line-height: 1;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -533,3 +533,57 @@ body.is-panning {
   transform: translateY(0) !important;
   opacity: 1 !important;
 }
+
+/* ============================================
+   Footer Text
+   ============================================ */
+
+.custom-slides-footer {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.55em;
+  color: rgba(100, 100, 100, 0.6);
+  font-family: var(--slides-font-text, inherit);
+  pointer-events: none;
+  z-index: 20;
+  white-space: nowrap;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+/* Footer text color for dark themes */
+.slides-theme-black .custom-slides-footer,
+.slides-theme-league .custom-slides-footer,
+.slides-theme-night .custom-slides-footer,
+.slides-theme-moon .custom-slides-footer,
+.slides-theme-dracula .custom-slides-footer,
+.slides-theme-blood .custom-slides-footer {
+  color: rgba(200, 200, 200, 0.4);
+}
+
+/* ============================================
+   Slide Numbers
+   ============================================ */
+
+.custom-slide-number {
+  position: absolute;
+  bottom: 16px;
+  font-size: 0.55em;
+  color: rgba(150, 150, 150, 0.7);
+  font-family: var(--slides-font-interface, var(--slides-font-text, inherit));
+  pointer-events: none;
+  z-index: 10;
+  line-height: 1;
+}
+
+.custom-slide-number.slide-number-bottom-left {
+  left: 24px;
+  right: auto;
+}
+
+.custom-slide-number.slide-number-bottom-right {
+  right: 160px;
+  left: auto;
+}

--- a/styles.css
+++ b/styles.css
@@ -540,14 +540,15 @@ body.is-panning {
 
 .custom-slides-footer {
   position: absolute;
-  bottom: 40px;
+  /* Dynamically position above the progress bar with CSS calc */
+  bottom: calc(var(--progress-height, 10px) + 20px);
   left: 50%;
   transform: translateX(-50%);
   font-size: 0.55em;
   color: rgba(100, 100, 100, 0.6);
   font-family: var(--slides-font-text, inherit);
   pointer-events: none;
-  z-index: 20;
+  z-index: 30;
   white-space: nowrap;
   text-align: center;
   letter-spacing: 0.02em;

--- a/styles.css
+++ b/styles.css
@@ -570,7 +570,8 @@ body.is-panning {
 
 .custom-slide-number {
   position: absolute;
-  bottom: 16px;
+  /* Dynamically position above the progress bar with CSS calc */
+  bottom: calc(var(--progress-height, 10px) + 6px);
   font-size: 0.55em;
   color: rgba(150, 150, 150, 0.7);
   font-family: var(--slides-font-interface, var(--slides-font-text, inherit));

--- a/styles.css
+++ b/styles.css
@@ -584,6 +584,12 @@ body.is-panning {
 }
 
 .custom-slide-number.slide-number-bottom-right {
-  right: 160px;
+  right: 24px;
   left: auto;
+}
+
+/* When navigate buttons or close button are visible, push the number inward to prevent overlap */
+body:not(.hide-navigate-right) .custom-slide-number.slide-number-bottom-right,
+body:not(.hide-close-btn) .custom-slide-number.slide-number-bottom-right {
+  right: 140px;
 }

--- a/styles.css
+++ b/styles.css
@@ -541,7 +541,7 @@ body.is-panning {
 .custom-slides-footer {
   position: absolute;
   /* Dynamically position above the progress bar with CSS calc */
-  bottom: calc(var(--progress-height, 10px) + 20px);
+  bottom: calc(var(--progress-height, 10px) + 12px);
   left: 50%;
   transform: translateX(-50%);
   font-size: 0.55em;
@@ -571,7 +571,7 @@ body.is-panning {
 .custom-slide-number {
   position: absolute;
   /* Dynamically position above the progress bar with CSS calc */
-  bottom: calc(var(--progress-height, 10px) + 6px);
+  bottom: calc(var(--progress-height, 10px) + 12px);
   font-size: 0.55em;
   color: rgba(150, 150, 150, 0.7);
   font-family: var(--slides-font-interface, var(--slides-font-text, inherit));


### PR DESCRIPTION
Hi @davidvkimball.

Thank you for this useful plugin. There were few features that in my team we wanted to add to this plugin. Here is the PR with these features. 

The features are:

- Add **configurable footer text** on all non-title slides with dark theme support
- Add toggleable **slide numbers** with bottom-left/bottom-right positioning
- Add **auto-fit** to shrink **overflowing slides** to fit the viewport

Please consider merging them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer text: configurable footer displayed on slides.
  * Slide numbers: optional slide numbers with choice of bottom-left or bottom-right positioning.
  * Auto-fit slides: optional auto-scaling to shrink overflowing content to fit the viewport; respects theme and updates during slide changes.

* **Documentation**
  * README updated with usage and settings for Footer text, Slide numbers, and Auto-fit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->